### PR TITLE
Small improvement

### DIFF
--- a/autoload/manpageview.vim
+++ b/autoload/manpageview.vim
@@ -521,7 +521,9 @@ fun! manpageview#ManPageView(viamap,bknum,...) range
 
   " let manpages format themselves to specified window width
   " this setting probably only affects the linux "man" command.
-  let $MANWIDTH= winwidth(0)
+  if $MANWIDTH == ""
+   let $MANWIDTH = winwidth(0)
+  endif
 
   " add some maps for multiple manpage handling {{{3
   " (some manpages on some systems have multiple NAME... topics provided on a single manpage)
@@ -763,8 +765,11 @@ fun! s:MPVSaveSettings()
   else
    let &sxq= ""
   endif
+
+  if $MANWIDTH == ""
+   let $MANWIDTH = winwidth(0)
+  endif
   let s:curmanwidth = $MANWIDTH
-  let $MANWIDTH     = winwidth(0)
 "  call Dret("s:MPVSaveSettings")
  endif
 


### PR DESCRIPTION
From Linux man(1) page:

MANWIDTH
   If $MANWIDTH is set, its value is used as the  line  length  for
   which  manual pages should be formatted.  If it is not set, man‐
   ual pages will be formatted with a line  length  appropriate  to
   the  current terminal (using an ioctl(2) if available, the value
   ...

I have set $MANWIDTH to '80' so it is easier to read man pages
in terminals, especially in maximized terminal windows. So this
fix to make manpageviee behaviour consistent with terminals.
